### PR TITLE
Leaf Variable inplace bug fix

### DIFF
--- a/lib/models/YOLOP.py
+++ b/lib/models/YOLOP.py
@@ -570,8 +570,8 @@ class MCnet(nn.Module):
         m = self.model[self.detector_index]  # Detect() module
         for mi, s in zip(m.m, m.stride):  # from
             b = mi.bias.view(m.na, -1)  # conv.bias(255) to (3,85)
-            b[:, 4] += math.log(8 / (640 / s) ** 2)  # obj (8 objects per 640 image)
-            b[:, 5:] += math.log(0.6 / (m.nc - 0.99)) if cf is None else torch.log(cf / cf.sum())  # cls
+            b.data[:, 4] += math.log(8 / (640 / s) ** 2)  # obj (8 objects per 640 image)
+            b.data[:, 5:] += math.log(0.6 / (m.nc - 0.99)) if cf is None else torch.log(cf / cf.sum())  # cls
             mi.bias = torch.nn.Parameter(b.view(-1), requires_grad=True)
 
 def get_net(cfg, **kwargs): 


### PR DESCRIPTION
Fixes
``` RuntimeError: a view of a leaf Variable that requires grad is being used in an in-place operation. ``` 

This error was observed while running on docker image ``` nvcr.io/nvidia/pytorch   21.06-py3 ```